### PR TITLE
Add public function to set GRPPWM register

### DIFF
--- a/PCA9624.h
+++ b/PCA9624.h
@@ -74,6 +74,10 @@ public:
         writeBytes(Reg::LEDOUT0, data, sizeof(data));
     }
 
+    void setGroupPWM(const uint8_t vol) {
+        writeByte(Reg::GRPPWM, vol);
+    }
+
     void drive(const uint8_t ch, const uint8_t vol) {
         writeByte(i2c_addr, (uint8_t)Reg::PWM0 + ch, vol);
     }


### PR DESCRIPTION
This allows group dimming, from the datasheet:

    When DMBLNK bit (MODE2 register) is programmed with logic 0, a 190 Hz
    fixed frequency signal is superimposed with the 97 kHz individual
    brightness control signal. GRPPWM is then used as a global brightness
    control allowing the LED outputs to be dimmed with the same value.